### PR TITLE
Add functionality for paginated requests to be indexed

### DIFF
--- a/src/deploy_key.rs
+++ b/src/deploy_key.rs
@@ -1,8 +1,11 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use colored::Colorize;
 
-use crate::{make_paginated_github_request, Bootstrap, Repository};
+use crate::{
+    make_paginated_github_request, make_paginated_github_request_with_index, Bootstrap, Member,
+    Repository,
+};
 
 #[derive(Debug, serde::Deserialize, Hash, Eq, PartialEq)]
 struct DeployKey {
@@ -18,21 +21,17 @@ struct DeployKey {
     enabled: bool,
 }
 
-#[derive(Debug, serde::Deserialize, Hash, Eq, PartialEq)]
-struct Member {
-    login: String,
-}
-
 pub fn run_audit(bootstrap: Bootstrap, _previous_csv: Option<String>) {
     println!("{}", "GitHub Deploy Key Audit".white().bold());
 
     println!("{}", "Fetching all organization members".yellow());
-    let members: HashSet<Member> = match make_paginated_github_request(
+    let members: HashMap<String, Member> = match make_paginated_github_request_with_index(
         &bootstrap.token,
         75,
         &format!("/orgs/{}/members", &bootstrap.org),
         3,
         None,
+        |member: &Member| member.login.clone(),
     ) {
         Ok(members) => members,
         Err(e) => {
@@ -72,9 +71,7 @@ pub fn run_audit(bootstrap: Bootstrap, _previous_csv: Option<String>) {
         };
 
         for deploy_key in deploy_keys {
-            if !members.contains(&Member {
-                login: deploy_key.added_by.clone(),
-            }) {
+            if !members.contains_key(&deploy_key.added_by) {
                 println!(
                     "{} has deploy key {} {}: {}",
                     repository.name.white(),

--- a/src/deploy_key.rs
+++ b/src/deploy_key.rs
@@ -31,7 +31,6 @@ pub fn run_audit(bootstrap: Bootstrap, _previous_csv: Option<String>) {
         &format!("/orgs/{}/members", &bootstrap.org),
         3,
         None,
-        |member: &Member| member.login.clone(),
     ) {
         Ok(members) => members,
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@ pub mod deploy_key;
 pub mod external_collaborator;
 pub mod members;
 
+pub trait GitHubIndex {
+    fn index(&self) -> String;
+}
+
 #[derive(Debug, serde::Deserialize, Hash, Eq, PartialEq)]
 struct Permissions {
     pull: bool,
@@ -32,7 +36,7 @@ struct Member {
     login: String,
 }
 
-impl Member {
+impl GitHubIndex for Member {
     fn index(&self) -> String {
         self.login.clone()
     }
@@ -217,124 +221,17 @@ fn make_paginated_github_request_with_index<T>(
     url: &str,
     retries: u8,
     params: Option<&str>,
-    indexer: impl Fn(&T) -> String,
 ) -> Result<HashMap<String, T>, String>
 where
-    T: serde::de::DeserializeOwned + std::hash::Hash + std::cmp::Eq,
+    T: serde::de::DeserializeOwned + std::hash::Hash + std::cmp::Eq + GitHubIndex,
 {
-    let params = match params {
-        Some(params) => format!("&{params}"),
-        None => String::new(),
-    };
+    let results: HashSet<T> =
+        make_paginated_github_request(gh_token, page_size, url, retries, params)?;
 
-    let mut page = 1;
-    let mut all_items = HashMap::new();
-    let mut tries = 0;
-    loop {
-        tries += 1;
-        let response = reqwest::blocking::Client::new()
-            .get(&format!(
-                "https://api.github.com{url}?per_page={page_size}&page={page}{params}",
-            ))
-            .header("User-Agent", "GitHub EC Audit")
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .header("Authorization", format!("Bearer {}", gh_token))
-            .send()
-            .map(|response| response.text());
-
-        // Handle communication issues with GitHub
-        let content = match response {
-            Ok(Ok(content)) => content,
-            Ok(Err(e)) => {
-                if tries >= retries {
-                    println!("{}", "Retries exhausted".red());
-                    return Err(e.to_string());
-                }
-
-                println!(
-                    "{}: {}",
-                    "Going to retry because couldn't read response from GitHub:".yellow(),
-                    e.to_string().red()
-                );
-
-                continue;
-            }
-            Err(e) => {
-                if tries >= retries {
-                    println!("{}", "Retries exhausted".red());
-                    return Err(e.to_string());
-                }
-
-                println!(
-                    "{}: {}",
-                    "Going to retry because couldn't make request to GitHub:".yellow(),
-                    e.to_string().red()
-                );
-
-                continue;
-            }
-        };
-
-        // Handle GitHub errors
-        match serde_json::from_str::<GitHubResponse<T>>(content.as_str()) {
-            Ok(GitHubResponse::Data(data)) => {
-                // When we go past the end (an unneeded page), we'll get an empty response so we can break
-                if data.is_empty() {
-                    break;
-                }
-
-                // The page is full so we need to add all these users to our set and grab the next page
-                page += 1;
-                tries = 0;
-
-                for item in data {
-                    all_items.insert(indexer(&item), item);
-                }
-            }
-            Ok(GitHubResponse::Error(e)) => {
-                // GitHub threw an error and if it's a ratelimit we can wait and retry
-                if e.message.contains("API rate limit exceeded") {
-                    sleep(Duration::from_secs(60));
-                } else {
-                    // This doesn't look like the expected data or a ratelimit error
-
-                    // We're out of retries so we need to stop
-                    if tries >= retries {
-                        println!("{}", "Retries exhausted".red());
-                        return Err(e.to_string());
-                    }
-
-                    // We have retries remaining so we'll try again
-                    println!(
-                        "{}: {}",
-                        "Going to retry because couldn't deserialize response from GitHub:"
-                            .yellow(),
-                        e.to_string().red()
-                    );
-                    tries += 1;
-                    println!("{}", content.yellow());
-                }
-            }
-            Err(e) => {
-                // This doesn't look like the expected data or an error
-                if tries >= retries {
-                    println!("{}", "Retries exhausted".red());
-                    return Err(e.to_string());
-                }
-
-                println!(
-                    "{}: {}",
-                    "Going to retry because couldn't deserialize response from GitHub:".yellow(),
-                    e.to_string().red()
-                );
-
-                println!("{}", content.yellow());
-            }
-        }
-    }
-
-    Ok(all_items)
+    Ok(results
+        .into_iter()
+        .map(|item| (item.index(), item))
+        .collect::<HashMap<String, T>>())
 }
 
 pub struct Bootstrap {

--- a/src/members.rs
+++ b/src/members.rs
@@ -40,7 +40,6 @@ pub fn run_admin_audit(bootstrap: Bootstrap, repos: Option<Vec<String>>) {
             &format!("/orgs/{}/members", &bootstrap.org),
             3,
             Some("role=admin"),
-            |member: &Member| member.login.clone(),
         ) {
             Ok(org_admins) => org_admins,
             Err(e) => {
@@ -107,7 +106,6 @@ pub fn run_admin_audit(bootstrap: Bootstrap, repos: Option<Vec<String>>) {
                         &format!("/orgs/{}/teams/{}/members", &bootstrap.org, team.slug),
                         3,
                         None,
-                        |member: &Member| member.login.clone(),
                     ) {
                         Ok(t) => t,
                         Err(e) => {

--- a/src/members.rs
+++ b/src/members.rs
@@ -2,14 +2,12 @@ use std::collections::{HashMap, HashSet};
 
 use colored::Colorize;
 
-use crate::{make_paginated_github_request, Bootstrap, Collaborator, Permissions, Repository};
+use crate::{
+    make_paginated_github_request, make_paginated_github_request_with_index, Bootstrap,
+    Collaborator, Member, Permissions, Repository,
+};
 
 pub fn run_audit(bootstrap: Bootstrap) {
-    #[derive(Debug, serde::Deserialize, Hash, Eq, PartialEq)]
-    struct Member {
-        avatar_url: String,
-    }
-
     let members: HashSet<Member> = match make_paginated_github_request(
         &bootstrap.token,
         100,
@@ -30,28 +28,25 @@ pub fn run_audit(bootstrap: Bootstrap) {
 
 pub fn run_admin_audit(bootstrap: Bootstrap, repos: Option<Vec<String>>) {
     #[derive(Debug, serde::Deserialize, Hash, Eq, PartialEq)]
-    struct Member {
-        login: String,
-    }
-
-    #[derive(Debug, serde::Deserialize, Hash, Eq, PartialEq)]
     struct Team {
         slug: String,
         permissions: Permissions,
     }
 
-    let organization_admins: HashSet<Member> = match make_paginated_github_request(
-        &bootstrap.token,
-        100,
-        &format!("/orgs/{}/members", &bootstrap.org),
-        3,
-        Some("role=admin"),
-    ) {
-        Ok(org_admins) => org_admins,
-        Err(e) => {
-            panic!("{}: {e}", "I couldn't fetch the organization members".red());
-        }
-    };
+    let organization_admins: HashMap<String, Member> =
+        match make_paginated_github_request_with_index(
+            &bootstrap.token,
+            100,
+            &format!("/orgs/{}/members", &bootstrap.org),
+            3,
+            Some("role=admin"),
+            |member: &Member| member.login.clone(),
+        ) {
+            Ok(org_admins) => org_admins,
+            Err(e) => {
+                panic!("{}: {e}", "I couldn't fetch the organization members".red());
+            }
+        };
 
     let repositories: HashSet<Repository> = match repos {
         Some(repos) => repos
@@ -64,7 +59,7 @@ pub fn run_admin_audit(bootstrap: Bootstrap, repos: Option<Vec<String>>) {
         None => bootstrap.fetch_all_repositories(75).unwrap(),
     };
 
-    let mut team_cache: HashMap<String, HashSet<Member>> = HashMap::new();
+    let mut team_cache: HashMap<String, HashMap<String, Member>> = HashMap::new();
 
     let one_percent = (repositories.len() as f64 * 0.01).ceil() as usize;
     let mut progress = 0;
@@ -105,22 +100,24 @@ pub fn run_admin_audit(bootstrap: Bootstrap, repos: Option<Vec<String>>) {
 
         for team in &repo_teams {
             if !team_cache.contains_key(&team.slug) {
-                let team_members: HashSet<Member> = match make_paginated_github_request(
-                    &bootstrap.token,
-                    25,
-                    &format!("/orgs/{}/teams/{}/members", &bootstrap.org, team.slug),
-                    3,
-                    None,
-                ) {
-                    Ok(t) => t,
-                    Err(e) => {
-                        panic!(
-                            "{} {}: {e}",
-                            repository.name.white(),
-                            "I couldn't fetch the repository collaborators".red()
-                        );
-                    }
-                };
+                let team_members: HashMap<String, Member> =
+                    match make_paginated_github_request_with_index(
+                        &bootstrap.token,
+                        25,
+                        &format!("/orgs/{}/teams/{}/members", &bootstrap.org, team.slug),
+                        3,
+                        None,
+                        |member: &Member| member.login.clone(),
+                    ) {
+                        Ok(t) => t,
+                        Err(e) => {
+                            panic!(
+                                "{} {}: {e}",
+                                repository.name.white(),
+                                "I couldn't fetch the repository collaborators".red()
+                            );
+                        }
+                    };
                 team_cache.insert(team.slug.clone(), team_members);
             }
         }
@@ -148,15 +145,11 @@ pub fn run_admin_audit(bootstrap: Bootstrap, repos: Option<Vec<String>>) {
         for collaborator in collaborators {
             // If this person is a repository admin and not an organization admin
             if collaborator.permissions.admin
-                && !organization_admins.contains(&Member {
-                    login: collaborator.login.clone(),
-                })
+                && !organization_admins.contains_key(&collaborator.login)
             {
                 // Check to see if they are a member of a team that gives them admin access
                 if repo_admin_teams.iter().fold(false, |acc, t| {
-                    acc || team_cache[&t.slug].contains(&Member {
-                        login: collaborator.login.clone(),
-                    })
+                    acc || team_cache[&t.slug].contains_key(&collaborator.login)
                 }) {
                     continue;
                 }


### PR DESCRIPTION
Instead of just returning a `HashSet`, there is a new trait on types that can be passed to the new `make_paginated_github_request_with_index` where it will return a `HashMap` instead which is indexed on what is returned from the new `GitHubIndex` trait.