### PR TITLE
Add BPR / ruleset audit

### DIFF
--- a/src/bpr.rs
+++ b/src/bpr.rs
@@ -1,0 +1,104 @@
+use std::fmt::Display;
+
+use colored::Colorize;
+
+use crate::{make_github_request, Bootstrap};
+
+fn get_default_branch(bootstrap: &Bootstrap, repo: impl Display) -> String {
+    match make_github_request(
+        &bootstrap.token,
+        &format!("/repos/{}/{repo}", bootstrap.org),
+        3,
+        None,
+    ) {
+        Ok(res) => {
+            res.get("default_branch")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string() // unwraps OK: required field in GH response
+        }
+        Err(e) => {
+            panic!(
+                "{} for repo {}: {}",
+                "I couldn't fetch the repo's default branch".red(),
+                repo,
+                e
+            );
+        }
+    }
+}
+
+fn get_bprs(bootstrap: &Bootstrap, repo: impl Display, branch: impl Display) -> String {
+    match make_github_request(
+        &bootstrap.token,
+        &format!(
+            "/repos/{}/{repo}/branches/{branch}/protection",
+            bootstrap.org
+        ),
+        3,
+        None,
+    ) {
+        Ok(res) => {
+            if res.get("status").is_some() && res.get("status").unwrap() == "404" {
+                return "Empty".to_string();
+            }
+            serde_json::to_string_pretty(&res).unwrap()
+        }
+        Err(e) => {
+            panic!(
+                "{} for repo {}: {}",
+                "I couldn't fetch the repo's BPRs".red(),
+                repo,
+                e
+            );
+        }
+    }
+}
+
+fn get_rulesets(bootstrap: &Bootstrap, repo: impl Display, branch: impl Display) -> String {
+    match make_github_request(
+        &bootstrap.token,
+        &format!("/repos/{}/{repo}/rules/branches/{branch}", bootstrap.org),
+        3,
+        None,
+    ) {
+        Ok(res) => serde_json::to_string_pretty(&res).unwrap(),
+        Err(e) => {
+            panic!(
+                "{} for repo {}: {}",
+                "I couldn't fetch the repo's rulesets".red(),
+                repo,
+                e
+            );
+        }
+    }
+}
+
+pub fn run_audit(bootstrap: Bootstrap, repos: Option<Vec<String>>) {
+    let repos = repos.unwrap_or_else(|| {
+        bootstrap
+            .fetch_all_repositories(75)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.name)
+            .collect::<Vec<String>>()
+    });
+
+    for repo in repos {
+        let default_branch = get_default_branch(&bootstrap, &repo);
+        println!(
+            "{} {}\n{} {}\n",
+            "          Repo:".yellow(),
+            repo.white(),
+            "Default branch:".yellow(),
+            default_branch.white()
+        );
+
+        let bprs = get_bprs(&bootstrap, &repo, &default_branch);
+        println!("{} {bprs}\n", "          BPRs:".yellow());
+
+        let rulesets = get_rulesets(&bootstrap, &repo, &default_branch);
+        println!("{} {rulesets}\n\n", "      Rulesets:".yellow());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use colored::Colorize;
+use gh_ec_audit::bpr;
 use gh_ec_audit::deploy_key;
 use gh_ec_audit::external_collaborator;
 
@@ -6,7 +7,6 @@ use clap::{command, Parser};
 use gh_ec_audit::members;
 use gh_ec_audit::Bootstrap;
 
-/// Simple program to greet a person
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -26,6 +26,10 @@ struct Args {
     #[arg(short, long)]
     admin: bool,
 
+    /// Run the BPR and rulesets audit
+    #[arg(short, long)]
+    bpr: bool,
+
     /// Limit the scanning to the given repos
     #[clap(short, long, value_delimiter = ',', num_args = 1..)]
     repos: Option<Vec<String>>,
@@ -36,6 +40,8 @@ struct Args {
 }
 
 fn main() {
+    let args = Args::parse();
+
     let bootstrap = match Bootstrap::new() {
         Ok(b) => b,
         Err(e) => {
@@ -43,8 +49,6 @@ fn main() {
             std::process::exit(1);
         }
     };
-
-    let args = Args::parse();
 
     if args.ec {
         external_collaborator::run_audit(bootstrap, args.previous);
@@ -54,6 +58,8 @@ fn main() {
         members::run_audit(bootstrap);
     } else if args.admin {
         members::run_admin_audit(bootstrap, args.repos);
+    } else if args.bpr {
+        bpr::run_audit(bootstrap, args.repos);
     } else {
         println!("No command specified");
     }


### PR DESCRIPTION
Added functionalities:
* Make a non-paginated GH request
* Fetch a repo's default branch
* Fetch BPRs for a given branch of a given repo
* Fetch rulesets for a given branch of a given repo

The BPR audit outputs pretty-printed JSON.