### PR TITLE
Add audit for empty GH teams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,12 @@ pub struct Repository {
     pub permissions: Permissions,
 }
 
+#[derive(serde::Deserialize, Hash, Eq, PartialEq)]
+pub struct Team {
+    pub name: String,
+    pub slug: String,
+}
+
 #[derive(Debug, serde::Deserialize, Hash, Eq, PartialEq)]
 #[serde(untagged)]
 enum GitHubResponse<T> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,13 @@ struct Args {
     #[arg(short, long)]
     bpr: bool,
 
-    /// Run the BPR and rulesets audit
+    /// Run the team permissions audit
     #[arg(short, long)]
     teamperm: bool,
+
+    /// Run the empty teams audit
+    #[arg(long)]
+    emptyteams: bool,
 
     #[arg(long)]
     team: Option<String>,
@@ -78,6 +82,8 @@ fn main() {
         } else {
             println!("Please specify a team with --team");
         }
+    } else if args.emptyteams {
+        teams::run_empty_teams_audit(bootstrap);
     } else {
         println!("No command specified");
     }

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use colored::Colorize;
 
-use crate::{make_paginated_github_request, Bootstrap, Repository};
+use crate::{make_github_request, make_paginated_github_request, Bootstrap, Repository, Team};
 
 /// Fetch all the repos for a given team and the permission it confers
 pub fn run_team_repo_audit(bootstrap: Bootstrap, team: String) {
@@ -32,5 +32,71 @@ pub fn run_team_repo_audit(bootstrap: Bootstrap, team: String) {
 
     for repo in team_repos {
         println!("{}: {}", repo.name, repo.permissions.highest_perm());
+    }
+}
+
+/// Fetch all empty teams, i.e., teams with no members
+pub fn run_empty_teams_audit(bootstrap: Bootstrap) {
+    println!(
+        "{}",
+        "I am going to fetch all teams from the org...".yellow()
+    );
+    // Get a list of all teams in the org
+    let teams: HashSet<Team> = match make_paginated_github_request(
+        &bootstrap.token,
+        25,
+        &format!("/orgs/{}/teams", &bootstrap.org),
+        3,
+        None,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            panic!(
+                "{}: {e}",
+                "I couldn't fetch the list of teams in the org".red()
+            );
+        }
+    };
+    println!(
+        "{} {} {}",
+        "Done: I found".green(),
+        teams.len().to_string().white(),
+        "teams".green()
+    );
+    println!("{}", "Now I will check for empty teams...".yellow());
+
+    // For each team, get a list of its members and see if it's empty.
+    // NOTE - We don't make a paginated request on purpose: we only want
+    // to see if a team is empty or not. As soon as we have some members,
+    // we want to move to the next team instead of fetching _all_ members.
+    for team in teams {
+        let members = match make_github_request(
+            &bootstrap.token,
+            &format!("/orgs/{}/teams/{}/members", bootstrap.org, team.slug),
+            3,
+            None,
+        ) {
+            Ok(members) => members,
+            Err(e) => {
+                panic!(
+                    "{} {}: {}",
+                    "I couldn't fetch the members of team".red(),
+                    team.name,
+                    e
+                );
+            }
+        };
+        let members = members.as_array().expect(&format!(
+            "{}",
+            "The value returned by GH is not an array".red()
+        ));
+
+        if members.is_empty() {
+            println!(
+                "{}: {}",
+                "Found an empty GH team".yellow(),
+                team.name.white()
+            );
+        }
     }
 }


### PR DESCRIPTION
Add an audit that fetches all teams in a GH org and prints if there are teams with no members (also including sub-teams). This can be useful for periodic clean-ups.