### PR TITLE
Add audit for codeowners files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "clap",
  "colored",
  "csv",
+ "lazy_static",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +102,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -339,12 +354,15 @@ dependencies = [
 name = "gh-ec-audit"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "clap",
  "colored",
  "csv",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "urlencoding",
 ]
 
 [[package]]
@@ -684,12 +702,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -748,7 +795,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1030,6 +1077,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+base64 = "0.22.1"
 clap = { version = "4.5.28", features = ["derive"] }
 colored = "2.0.0"
 csv = "1.3"
+regex = "1.11.1"
 reqwest = { version = "0.11.6", features = ["blocking", "json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
+urlencoding = "2.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ base64 = "0.22.1"
 clap = { version = "4.5.28", features = ["derive"] }
 colored = "2.0.0"
 csv = "1.3"
-regex = "1.11.1"
+regex = "1.11"
 reqwest = { version = "0.11.6", features = ["blocking", "json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-base64 = "0.22.1"
-clap = { version = "4.5.28", features = ["derive"] }
-colored = "2.0.0"
+base64 = "0.22"
+clap = { version = "4.5", features = ["derive"] }
+colored = "2.0"
 csv = "1.3"
+lazy_static = "1.5"
 regex = "1.11"
-reqwest = { version = "0.11.6", features = ["blocking", "json"] }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.68"
-urlencoding = "2.1.3"
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+urlencoding = "2.1"

--- a/src/codeowners/audit.rs
+++ b/src/codeowners/audit.rs
@@ -1,0 +1,139 @@
+use std::collections::HashSet;
+
+use crate::{make_github_request, Bootstrap, Member, Team};
+
+use super::CodeownersFile;
+use colored::Colorize;
+
+/// Run the audit on a given list of CO files
+pub fn audit_co_files(
+    bootstrap: &Bootstrap,
+    codeowners_files: &[CodeownersFile],
+    org_members: &HashSet<Member>,
+    org_teams: &HashSet<Team>,
+) {
+    // Keep a growing cache of empty and non-empty teams to make checks more efficient.
+    let mut non_empty_teams = HashSet::<String>::new();
+    let mut empty_teams = HashSet::<String>::new();
+
+    for co_file in codeowners_files {
+        let mut no_errors = true;
+
+        // Check if all the users mentioned in the CO file are in the org
+        for user in &co_file.users {
+            if org_members.iter().find(|u| u.login == *user).is_none() {
+                no_errors = false;
+                println!(
+                    "{} {} {} {} {}",
+                    "Error in CODEOWNERS file".red(),
+                    co_file.url.white(),
+                    "User".red(),
+                    user.white(),
+                    "does not belong to the org".red()
+                );
+            }
+        }
+
+        // Check if all the teams mentioned in the CO file exist and alert if a team is empty.
+        for team in &co_file.teams {
+            match org_teams.iter().find(|t| t.slug == *team) {
+                None => {
+                    no_errors = false;
+                    println!(
+                        "{} {} {} {} {}",
+                        "Error in CODEOWNERS file".red(),
+                        co_file.url.white(),
+                        "Team".red(),
+                        team.white(),
+                        "does not exist in the org".red()
+                    );
+                }
+                Some(t) => {
+                    // Check if the team is empty, by first looking into the cache: if
+                    // it's not there, we call GH API and update the cache accordingly.
+                    // Note - the || operator short-circuits, so we are making the call to GH API
+                    // only if the team is not in our cache.
+                    if empty_teams.contains(&t.slug) || t.is_empty(&bootstrap) {
+                        no_errors = false;
+                        println!(
+                            "{} {} {} {}",
+                            "Warning! CODEOWNERS file".yellow(),
+                            co_file.url.white(),
+                            "contains an empty team:".yellow(),
+                            t.slug.white(),
+                        );
+                        empty_teams.insert(t.slug.clone());
+                    } else {
+                        // The team is not empty. Let's insert it into the non-empty cache (repeated
+                        // insertions don't matter because it's a HashSet).
+                        non_empty_teams.insert(t.slug.clone());
+                    }
+                }
+            }
+        }
+
+        if no_errors {
+            println!(
+                "{} {}",
+                "No errors detected in CODEOWNERS file for repo".green(),
+                co_file.repo.white()
+            );
+        }
+    }
+}
+
+/// Audit CODEOWNERS files for errors by asking the GH REST API.  
+/// For more info, see https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-codeowners-errors
+pub fn audit_co_files_with_gh_api(bootstrap: &Bootstrap, repos: &[String]) {
+    for repo in repos {
+        // Call the GH API
+        match get_codeowners_errors(&bootstrap, &repo) {
+            Ok(kinds) => {
+                if kinds.is_empty() {
+                    println!(
+                        "{} {}",
+                        "No errors detected in CODEOWNERS file for repo".green(),
+                        repo.white()
+                    );
+                } else {
+                    println!(
+                        "{} {}: {:?}",
+                        "Errors detected in CODEOWNERS file for repo".red(),
+                        repo.white(),
+                        kinds
+                    );
+                }
+            }
+            Err(e) => {
+                println!(
+                    "{} {} {} {}",
+                    "Warning!".yellow(),
+                    e.white(),
+                    "for repo".yellow(),
+                    repo.white()
+                );
+            }
+        }
+    }
+}
+
+/// Call the GH API and retrieve errors detected in the CODEOWNERS file.
+fn get_codeowners_errors(bootstrap: &Bootstrap, repo: &str) -> Result<Vec<String>, String> {
+    let url = format!("/repos/{}/{repo}/codeowners/errors", bootstrap.org);
+    let res = make_github_request(&bootstrap.token, &url, 3, None).unwrap();
+    match res.get("errors") {
+        None => {
+            // If this field is not present, it means a CO file has not been found
+            return Err("CODEOWNERS file not found".to_string());
+        }
+        Some(errors) => {
+            let kinds: Vec<String> = errors
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|e| e.get("kind").unwrap().as_str().unwrap().to_string())
+                .collect();
+            Ok(kinds)
+        }
+    }
+}

--- a/src/codeowners/audit.rs
+++ b/src/codeowners/audit.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{make_github_request, Bootstrap, Member, Team};
 
-use super::CodeownersFile;
+use super::{CodeownersFile, CodeownersFileProblem};
 use colored::Colorize;
 
 /// Run the audit on a given list of CO files
@@ -11,129 +11,191 @@ pub fn audit_co_files(
     codeowners_files: &[CodeownersFile],
     org_members: &HashMap<String, Member>,
     org_teams: &HashMap<String, Team>,
+    also_gh_api: bool,
+    verbose: bool,
 ) {
     // Keep a growing cache of empty and non-empty teams to make checks more efficient.
-    let mut non_empty_teams = HashSet::<String>::new();
-    let mut empty_teams = HashSet::<String>::new();
+    let mut non_empty_teams = HashSet::new();
+    let mut empty_teams = HashSet::new();
 
     for co_file in codeowners_files {
-        let mut no_errors = true;
-
         // Check if all the users mentioned in the CO file are in the org
-        for user in &co_file.users {
-            if !org_members.contains_key(user) {
-                no_errors = false;
-                println!(
-                    "{} {} {} {} {}",
-                    "Error in CODEOWNERS file".red(),
-                    co_file.url.white(),
-                    "User".red(),
-                    user.white(),
-                    "does not belong to the org".red()
-                );
-            }
-        }
+        let mut co_problems = co_file
+            .users
+            .iter()
+            .filter_map(|user| {
+                if !org_members.contains_key(user) {
+                    Some(CodeownersFileProblem::UserNotInOrg {
+                        user: user.to_string(),
+                        co_file_url: co_file.url.clone(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<CodeownersFileProblem>>();
 
         // Check if all the teams mentioned in the CO file exist and alert if a team is empty.
-        for team in &co_file.teams {
-            if !org_teams.contains_key(team) {
-                no_errors = false;
+        co_problems.extend(
+            co_file
+                .teams
+                .iter()
+                .filter_map(|team| {
+                    if !org_teams.contains_key(team) {
+                        Some(CodeownersFileProblem::TeamNotInOrg {
+                            team: team.to_string(),
+                            co_file_url: co_file.url.clone(),
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<CodeownersFileProblem>>(),
+        );
+
+        // See if we have any warnings
+        co_problems.extend(
+            co_file
+                .teams
+                .iter()
+                .filter_map(|team| {
+                    // Check if the team is empty, by first looking into the cache: if
+                    // it's not there, we call the GH API and update the cache accordingly.
+                    // Note - the || operator short-circuits, so we are making the call to GH API
+                    // only if the team is not in our cache.
+                    match org_teams.get(team) {
+                        Some(t) => {
+                            if empty_teams.contains(&t.slug) || {
+                                match t.is_empty(bootstrap) {
+                                    Ok(empty) => empty,
+                                    Err(e) => {
+                                        // For some reason, we could not establish if the team is empty. Log a warning and return false (i.e., not empty),
+                                        // which is equivalent to ignoring it (because we are not alerting on non-empty teams).
+                                        // This should anyway be a very rare circumstance.
+                                        println!(
+                                            "{} {} {} {}",
+                                            "Warning! I could not determine if team".yellow(),
+                                            t.slug.white(),
+                                            "is empty. I am going to ignore it. The error was"
+                                                .yellow(),
+                                            e.white()
+                                        );
+                                        false
+                                    }
+                                }
+                            } {
+                                // The team is empty
+                                empty_teams.insert(t.slug.clone());
+                                Some(CodeownersFileProblem::EmptyTeam {
+                                    team: team.to_string(),
+                                    co_file_url: co_file.url.clone(),
+                                })
+                            } else {
+                                // The team is not empty. Let's insert it into the non-empty cache (repeated
+                                // insertions don't matter because it's a HashSet).
+                                non_empty_teams.insert(t.slug.clone());
+                                None
+                            }
+                        }
+                        None => {
+                            // This means the team does not exist in the org. This is actually an error
+                            // which will have been caught above. So we can safely ignore it here.
+                            None
+                        }
+                    }
+                })
+                .collect::<Vec<CodeownersFileProblem>>(),
+        );
+
+        // Print all the errors and warnings, if any
+        if co_problems.is_empty() {
+            // By default, we print nothing if there was nothing wrong. But we can print if a verbose flag was passed.
+            if verbose {
                 println!(
-                    "{} {} {} {} {}",
-                    "Error in CODEOWNERS file".red(),
-                    co_file.url.white(),
-                    "Team".red(),
-                    team.white(),
-                    "does not exist in the org".red()
+                    "{} {}",
+                    "No problems detected in CODEOWNERS file for repo".green(),
+                    co_file.repo.white()
                 );
-                continue;
             }
-
-            let t = org_teams.get(team).unwrap(); // unwrap OK: we checked above
-
-            // Check if the team is empty, by first looking into the cache: if
-            // it's not there, we call the GH API and update the cache accordingly.
-            // Note - the || operator short-circuits, so we are making the call to GH API
-            // only if the team is not in our cache.
-            if empty_teams.contains(&t.slug) || t.is_empty(&bootstrap) {
-                no_errors = false;
-                println!(
-                    "{} {} {} {}",
-                    "Warning! CODEOWNERS file".yellow(),
-                    co_file.url.white(),
-                    "contains an empty team:".yellow(),
-                    t.slug.white(),
-                );
-                empty_teams.insert(t.slug.clone());
-            } else {
-                // The team is not empty. Let's insert it into the non-empty cache (repeated
-                // insertions don't matter because it's a HashSet).
-                non_empty_teams.insert(t.slug.clone());
+        } else {
+            for problem in co_problems {
+                println!("{problem}");
             }
         }
 
-        if no_errors {
-            println!(
-                "{} {}",
-                "No errors detected in CODEOWNERS file for repo".green(),
-                co_file.repo.white()
-            );
+        // If we were told to also use the GH API, we do it here
+        if also_gh_api {
+            println!("This is what the GitHub API has to say about this CODEOWNERS file...");
+            audit_co_files_with_gh_api(bootstrap, &co_file.repo);
         }
     }
 }
 
 /// Audit CODEOWNERS files for errors by asking the GH REST API.  
 /// For more info, see https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-codeowners-errors
-pub fn audit_co_files_with_gh_api(bootstrap: &Bootstrap, repos: &[String]) {
-    for repo in repos {
-        // Call the GH API
-        match get_codeowners_errors(&bootstrap, &repo) {
-            Ok(kinds) => {
-                if kinds.is_empty() {
-                    println!(
-                        "{} {}",
-                        "No errors detected in CODEOWNERS file for repo".green(),
-                        repo.white()
-                    );
-                } else {
-                    println!(
-                        "{} {}: {:?}",
-                        "Errors detected in CODEOWNERS file for repo".red(),
-                        repo.white(),
-                        kinds
-                    );
-                }
-            }
-            Err(e) => {
+fn audit_co_files_with_gh_api(bootstrap: &Bootstrap, repo: &str) {
+    // Call the GH API
+    match get_codeowners_errors(&bootstrap, &repo) {
+        Ok(Some(kinds)) => {
+            // A CODEOWNERS file was found and a (possibly empty) Vec of errors was returned
+            if kinds.is_empty() {
                 println!(
-                    "{} {} {} {}",
-                    "Warning!".yellow(),
-                    e.white(),
-                    "for repo".yellow(),
+                    "{} {}",
+                    "No errors detected in CODEOWNERS file for repo".green(),
                     repo.white()
                 );
+            } else {
+                println!(
+                    "{} {}: {:?}",
+                    "Errors detected in CODEOWNERS file for repo".red(),
+                    repo.white(),
+                    kinds
+                );
             }
+        }
+        Ok(None) => {
+            // A CODEOWNERS file was not found
+            println!(
+                "{} {}",
+                "CODEOWNERS file not found for repository".yellow(),
+                repo.white()
+            );
+        }
+        Err(e) => {
+            // The call to GH failed
+            println!(
+                "{} {} {} {}",
+                "Warning! Call to GitHub API failed with error".yellow(),
+                e.white(),
+                "for repo".yellow(),
+                repo.white()
+            );
         }
     }
 }
 
 /// Call the GH API and retrieve errors detected in the CODEOWNERS file.
-fn get_codeowners_errors(bootstrap: &Bootstrap, repo: &str) -> Result<Vec<String>, String> {
+fn get_codeowners_errors(bootstrap: &Bootstrap, repo: &str) -> Result<Option<Vec<String>>, String> {
     let url = format!("/repos/{}/{repo}/codeowners/errors", bootstrap.org);
-    let res = make_github_request(&bootstrap.token, &url, 3, None).unwrap();
+    let res = make_github_request(&bootstrap.token, &url, 3, None)?;
     match res.get("errors") {
         None => {
             // If this field is not present, it means a CO file has not been found
-            return Err("CODEOWNERS file not found".to_string());
+            return Ok(None);
         }
         Some(errors) => {
             let kinds: Vec<String> = errors
                 .as_array()
-                .unwrap()
+                .ok_or("Unexpected format received: it's not an array".to_string())?
                 .iter()
-                .map(|e| e.get("kind").unwrap().as_str().unwrap().to_string())
+                .map(|e| {
+                    e.get("kind")
+                        .and_then(|k| k.as_str())
+                        .and_then(|s| Some(s.to_string()))
+                        .unwrap_or("Unknown".to_string())
+                })
                 .collect();
-            Ok(kinds)
+            Ok(Some(kinds))
         }
     }
 }

--- a/src/codeowners/iterate.rs
+++ b/src/codeowners/iterate.rs
@@ -14,6 +14,7 @@ fn get_co_file(bootstrap: &Bootstrap, repo: &str) -> (String, String) {
     let mut content = String::new();
     let mut html_url = String::new();
     for location in CO_LOCATIONS {
+        // Try to download the file and fill in `content` and `html_url`
         let url = format!("/repos/{}/{}/contents/{}", bootstrap.org, repo, location);
         let res = make_github_request(&bootstrap.token, &url, 3, None);
         match res {

--- a/src/codeowners/iterate.rs
+++ b/src/codeowners/iterate.rs
@@ -2,7 +2,7 @@ use colored::Colorize;
 
 use crate::{make_github_request, utils::process_fetch_file_result, Bootstrap};
 
-use super::{codeowner_content_to_obj, CodeownersFile};
+use super::CodeownersFile;
 
 /// Locations where a CODEOWNERS file can be placed, sorted by priority.
 /// For more info, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
@@ -10,61 +10,69 @@ const CO_LOCATIONS: [&str; 3] = [".github/CODEOWNERS", "CODEOWNERS", "docs/CODEO
 
 /// Search for a CO file in the possible locations and download the file, returning its content and HTML URL. Stop as soon as a matching file is found.  
 /// From GH docs: "If CODEOWNERS files exist in more than one of those locations, GitHub will search for them in that order and use the first one it finds.""
-fn get_co_file(bootstrap: &Bootstrap, repo: &str) -> Option<(String, String)> {
+fn get_co_file(bootstrap: &Bootstrap, repo: &str) -> Result<Option<CodeownersFile>, String> {
     for location in CO_LOCATIONS {
         // Try to download the file and fill in `content` and `html_url`
         let url = format!("/repos/{}/{}/contents/{}", bootstrap.org, repo, location);
         let res = make_github_request(&bootstrap.token, &url, 3, None);
         match res {
-            Err(_) => continue, // This call failed, keep going
+            Err(_) => continue, // The call for this location failed, keep going
             Ok(v) => {
-                match v.get("status") {
-                    None => {}
-                    Some(s) => {
-                        if s.as_str().unwrap() == "404" {
-                            // This means the file was not found
+                // If we have a status, check it to see if GH is telling us the file does not exist
+                if let Some(s) = v.get("status") {
+                    match s.as_str() {
+                        Some(status) => {
+                            if status == "404" {
+                                // This means the file was not found
+                                continue;
+                            }
+                        }
+                        None => {
+                            // This is very strange
                             continue;
                         }
                     }
                 }
-                let html_url = v.get("html_url").unwrap().as_str().unwrap().to_string();
-                let content = process_fetch_file_result(v);
-
-                if let Some(content) = content {
-                    return Some((content, html_url));
+                let html_url = v
+                    .get("html_url")
+                    .and_then(|u| u.as_str())
+                    .and_then(|s| Some(s.to_string()))
+                    .unwrap_or("Not available".to_string());
+                if let Ok(content) = process_fetch_file_result(v) {
+                    return Ok(Some(CodeownersFile::parse_from_content(
+                        bootstrap, content, &html_url, repo,
+                    )));
                 } else {
-                    // We return None instead of continuing the for-loop because a file was found:
+                    // We return instead of continuing the for-loop because a file was found:
                     // we just did not manage to get its content, for some reason.
-                    return None;
+                    return Err("Could not read the content of CODEOWNERS file".to_string());
                 }
             }
         }
     }
     // If we are here, then no CO file was found
-    None
+    Ok(None)
 }
 
 /// Find all the codeowners files in an organization
 pub fn find_codeowners_in_org(
     bootstrap: &Bootstrap,
     repos: Option<Vec<String>>,
-) -> Vec<CodeownersFile> {
-    let repos = repos.unwrap_or_else(|| {
-        bootstrap
-            .fetch_all_repositories(75)
-            .unwrap()
+) -> Result<Vec<CodeownersFile>, String> {
+    let repos = match repos {
+        Some(v) => v,
+        None => bootstrap
+            .fetch_all_repositories(75)?
             .into_iter()
             .map(|r| r.name)
-            .collect::<Vec<String>>()
-    });
+            .collect::<Vec<String>>(),
+    };
 
     let mut all_results = vec![];
 
     for repo in repos {
-        if let Some((content, html_url)) = get_co_file(bootstrap, &repo) {
-            all_results.push(codeowner_content_to_obj(
-                bootstrap, content, &html_url, &repo,
-            ));
+        if let Ok(Some(co_file)) = get_co_file(bootstrap, &repo) {
+            all_results.push(co_file);
         } else {
             // We did not manage to fill the content: this means we did not find a CODEOWNERS for this repo
             println!(
@@ -76,21 +84,22 @@ pub fn find_codeowners_in_org(
         }
     }
 
-    all_results
+    Ok(all_results)
 }
 
 /// Find all occurrences of a given team in an organization's codeowners files
 pub fn find_team_in_codeowners(bootstrap: &Bootstrap, team: String, repos: Option<Vec<String>>) {
-    let code_owners = find_codeowners_in_org(bootstrap, repos);
-    for co in code_owners {
-        if co.teams.contains(&team) {
-            println!(
-                "{} {:<50} - {} {}",
-                "Repository:".yellow(),
-                co.repo.white(),
-                "URL:".yellow(),
-                co.url.white()
-            )
+    if let Ok(code_owners) = find_codeowners_in_org(bootstrap, repos) {
+        for co in code_owners {
+            if co.teams.contains(&team) {
+                println!(
+                    "{} {:<50} - {} {}",
+                    "Repository:".yellow(),
+                    co.repo.white(),
+                    "URL:".yellow(),
+                    co.url.white()
+                )
+            }
         }
     }
 }

--- a/src/codeowners/iterate.rs
+++ b/src/codeowners/iterate.rs
@@ -29,7 +29,14 @@ fn get_co_file(bootstrap: &Bootstrap, repo: &str) -> Option<(String, String)> {
                 }
                 let html_url = v.get("html_url").unwrap().as_str().unwrap().to_string();
                 let content = process_fetch_file_result(v);
-                return Some((content, html_url));
+
+                if let Some(content) = content {
+                    return Some((content, html_url));
+                } else {
+                    // We return None instead of continuing the for-loop because a file was found:
+                    // we just did not manage to get its content, for some reason.
+                    return None;
+                }
             }
         }
     }

--- a/src/codeowners/iterate.rs
+++ b/src/codeowners/iterate.rs
@@ -1,0 +1,90 @@
+use colored::Colorize;
+
+use crate::{make_github_request, utils::process_fetch_file_result, Bootstrap};
+
+use super::{codeowner_content_to_obj, CodeownersFile};
+
+/// Locations where a CODEOWNERS file can be placed, sorted by priority.
+/// For more info, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
+const CO_LOCATIONS: [&str; 3] = [".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"];
+
+/// Search for CO file in the possible locations and download the file.
+/// Stop as soon as a matching file is found.
+fn get_co_file(bootstrap: &Bootstrap, repo: &str) -> (String, String) {
+    let mut content = String::new();
+    let mut html_url = String::new();
+    for location in CO_LOCATIONS {
+        let url = format!("/repos/{}/{}/contents/{}", bootstrap.org, repo, location);
+        let res = make_github_request(&bootstrap.token, &url, 3, None);
+        match res {
+            Err(_) => continue, // This call failed, keep going
+            Ok(v) => {
+                match v.get("status") {
+                    None => {}
+                    Some(s) => {
+                        if s.as_str().unwrap() == "404" {
+                            // This means the file was not found
+                            continue;
+                        }
+                    }
+                }
+                html_url = v.get("html_url").unwrap().as_str().unwrap().to_string();
+                content = process_fetch_file_result(v);
+                break;
+            }
+        }
+    }
+    (content, html_url)
+}
+
+/// Find all the codeowners files in an organization
+pub fn find_codeowners_in_org(
+    bootstrap: &Bootstrap,
+    repos: Option<Vec<String>>,
+) -> Vec<CodeownersFile> {
+    let repos = repos.unwrap_or_else(|| {
+        bootstrap
+            .fetch_all_repositories(75)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.name)
+            .collect::<Vec<String>>()
+    });
+
+    let mut all_results = vec![];
+
+    for repo in repos {
+        let (content, html_url) = get_co_file(bootstrap, &repo);
+        if content == "" {
+            // We did not manage to fill the content: this means we did not find a CODEOWNERS for this repo
+            println!(
+                "{} {}",
+                "Warning! CODEOWNERS file not found for repository".red(),
+                repo.white()
+            );
+            continue;
+        }
+
+        all_results.push(codeowner_content_to_obj(
+            bootstrap, content, &html_url, &repo,
+        ));
+    }
+
+    all_results
+}
+
+/// Find all occurrences of a given team in an organization's codeowners files
+pub fn find_team_in_codeowners(bootstrap: &Bootstrap, team: String, repos: Option<Vec<String>>) {
+    let code_owners = find_codeowners_in_org(bootstrap, repos);
+    for co in code_owners {
+        if co.teams.contains(&team) {
+            println!(
+                "{} {:<50} - {} {}",
+                "Repository:".yellow(),
+                co.repo.white(),
+                "URL:".yellow(),
+                co.url.white()
+            )
+        }
+    }
+}

--- a/src/codeowners/mod.rs
+++ b/src/codeowners/mod.rs
@@ -1,0 +1,185 @@
+/// Use an iterative approach, i.e., scan repos one by one
+mod iterate;
+/// Leverage the GH search API to find relevant information
+mod search;
+
+use std::collections::HashSet;
+
+use crate::{members::get_org_members, teams::get_org_teams, Bootstrap};
+use colored::Colorize;
+use regex::Regex;
+
+/// Represents a CODEOWNERS file
+#[derive(Debug)]
+struct CodeownersFile {
+    /// Repository this CO file belongs to
+    repo: String,
+    /// HTML URL, to give the user a quick way to reach the file
+    url: String,
+    /// List of all users mentioned in the file, for further analysis
+    users: HashSet<String>,
+    /// List of all teams mentioned in the file, for further analysis
+    teams: HashSet<String>,
+}
+
+/// Run the audit on CODEOWNERS files
+pub fn run_codeowners_audit(
+    bootstrap: Bootstrap,
+    team: Option<String>,
+    repos: Option<Vec<String>>,
+    search: bool,
+) {
+    if search && repos.is_some() {
+        panic!("{}", "Using --search assumes an org-wide search, and it is not supported in conjunction with a list of repos (i.e., --repos).".red());
+    }
+
+    if team.is_none() {
+        // If we don't receive a team, then we audit all CODEOWNERS files in the org.
+        // This means we will look at the CODEOWNERS files and determine
+        // * If all users mentioned in the file exist and are members of the org
+        // * If all teams mentioned in the file exist
+        // We will also alert if a team is empty.
+        println!(
+            "{}",
+            "Searching for CODEOWNERS files across the org...".yellow()
+        );
+
+        let codeowners_files = match search {
+            true => search::find_codeowners_in_org(&bootstrap),
+            false => iterate::find_codeowners_in_org(&bootstrap, repos),
+        };
+
+        println!(
+            "{} {} {}",
+            "Done! I found".green(),
+            codeowners_files.len().to_string().white(),
+            "CODEOWNERS files".green()
+        );
+
+        println!(
+            "{}",
+            "Preparing to analyze these CODEOWNERS files...".yellow()
+        );
+
+        // Get all members and teams in the org, so that we can efficiently
+        // cross-check the content of all the CODEOWNERS files we have found.
+        let org_members = get_org_members(&bootstrap);
+        let org_teams = get_org_teams(&bootstrap);
+
+        // Keep a growing cache of empty and non-empty teams to make checks more efficient.
+        let mut non_empty_teams = HashSet::<String>::new();
+        let mut empty_teams = HashSet::<String>::new();
+
+        for co_file in codeowners_files {
+            // Check if all the users are in the org
+            for user in co_file.users {
+                if org_members.iter().find(|u| u.login == user).is_none() {
+                    println!(
+                        "{} {} {} {} {}",
+                        "Error in CODEOWNERS file".red(),
+                        co_file.url.white(),
+                        "User".red(),
+                        user.white(),
+                        "does not belong to the org".red()
+                    );
+                }
+            }
+
+            // Check if all the teams exist and alert if a team is empty
+            for team in co_file.teams {
+                match org_teams.iter().find(|t| t.slug == team) {
+                    None => {
+                        println!(
+                            "{} {} {} {} {}",
+                            "Error in CODEOWNERS file".red(),
+                            co_file.url.white(),
+                            "Team".red(),
+                            team.white(),
+                            "does not exist in the org".red()
+                        );
+                    }
+                    Some(t) => {
+                        // Let's check if the team is empty or not by first looking into our cache
+                        if non_empty_teams.contains(&t.slug) {
+                            // Nothing more to be done
+                            continue;
+                        }
+                        // If we are here, the team might be empty. Let's again look in the cache: if
+                        // it's not there, let's call GH API and update the cache accordingly.
+                        // Note - the || operator short-circuits, so we are making the call to GH API
+                        // only if the team is not in our cache.
+                        if empty_teams.contains(&t.slug) || t.is_empty(&bootstrap) {
+                            println!(
+                                "{} {} {} {}",
+                                "Warning! CODEOWNERS file".red(),
+                                co_file.url.white(),
+                                "contains an empty team:".red(),
+                                t.slug.white(),
+                            );
+                            empty_teams.insert(t.slug.clone());
+                        } else {
+                            non_empty_teams.insert(t.slug.clone());
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        // If we do receive a team, then we will look for all occurrences of that team in CODEOWNERS files across the org.
+        // This is useful to estimate the impact on CODEOWNERS that removing or renaming a team would have.
+        let team = team.unwrap();
+        println!(
+            "{} {} {}",
+            "Searching for occurrences of team".yellow(),
+            team.white(),
+            "in CODEOWNERS files...".yellow()
+        );
+        match search {
+            true => search::find_team_in_codeowners(&bootstrap, team),
+            false => iterate::find_team_in_codeowners(&bootstrap, team, repos),
+        }
+    }
+}
+
+/// Process the content of a CO file and turn it into a CodeownersFile struct
+fn codeowner_content_to_obj(
+    bootstrap: &Bootstrap,
+    content: String,
+    html_url: &str,
+    repo: &str,
+) -> CodeownersFile {
+    // Get users and teams mentioned in this CODEOWNERS file
+    // Find matches that look like @something, and then decide if it's a user or a team
+    let regex = Regex::new(r"@\S+").unwrap();
+
+    let mut users = HashSet::new();
+    let mut teams = HashSet::new();
+
+    // The prefix that teams have in CO files
+    let team_prefix = format!("@{}/", bootstrap.org);
+
+    for line in content.split('\n') {
+        if line.starts_with('#') {
+            // Skip comments
+            continue;
+        }
+
+        for m in regex.find_iter(line) {
+            let matched = m.as_str();
+            if matched.starts_with(&team_prefix) {
+                // It's a team
+                teams.insert(matched.trim_start_matches(&team_prefix).to_string());
+            } else {
+                // It's a user
+                users.insert(matched.trim_start_matches("@").to_string());
+            }
+        }
+    }
+
+    CodeownersFile {
+        repo: repo.to_string(),
+        url: html_url.to_string(),
+        users,
+        teams,
+    }
+}

--- a/src/codeowners/mod.rs
+++ b/src/codeowners/mod.rs
@@ -4,14 +4,19 @@ mod iterate;
 /// Leverage the GH search API to find relevant information
 mod search;
 
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::Display};
 
 use crate::{members::get_indexed_org_members, teams::get_indexed_org_teams, Bootstrap};
 use colored::Colorize;
+use lazy_static::lazy_static;
 use regex::Regex;
 
+lazy_static! {
+    /// Regex used to find matches in CO files that look like @something.
+    static ref co_regex: Regex = Regex::new(r"@\S+").unwrap();
+}
+
 /// Represents a CODEOWNERS file
-#[derive(Debug)]
 struct CodeownersFile {
     /// Repository this CO file belongs to
     repo: String,
@@ -21,6 +26,89 @@ struct CodeownersFile {
     users: HashSet<String>,
     /// List of all teams mentioned in the file, for further analysis
     teams: HashSet<String>,
+}
+
+impl CodeownersFile {
+    /// Process the content of a CO file and turn it into a CodeownersFile struct
+    fn parse_from_content(
+        bootstrap: &Bootstrap,
+        content: String,
+        html_url: &str,
+        repo: &str,
+    ) -> CodeownersFile {
+        let mut users = HashSet::new();
+        let mut teams = HashSet::new();
+
+        // The prefix that teams have in CO files
+        let team_prefix = format!("@{}/", bootstrap.org);
+
+        for line in content.split('\n') {
+            if line.trim().starts_with('#') {
+                // Skip comments
+                continue;
+            }
+
+            for m in co_regex.find_iter(line) {
+                let matched = m.as_str();
+                if matched.starts_with(&team_prefix) {
+                    // It's a team
+                    teams.insert(matched.trim_start_matches(&team_prefix).to_string());
+                } else {
+                    // It's a user
+                    users.insert(matched.trim_start_matches("@").to_string());
+                }
+            }
+        }
+
+        CodeownersFile {
+            repo: repo.to_string(),
+            url: html_url.to_string(),
+            users,
+            teams,
+        }
+    }
+}
+
+/// The problems we can encounter while auditing a CODEOWNERS file
+enum CodeownersFileProblem {
+    UserNotInOrg { user: String, co_file_url: String },
+    TeamNotInOrg { team: String, co_file_url: String },
+    EmptyTeam { team: String, co_file_url: String },
+}
+
+impl Display for CodeownersFileProblem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            CodeownersFileProblem::EmptyTeam { team, co_file_url } => format!(
+                "{} {} {} {}",
+                "Warning! CODEOWNERS file".yellow(),
+                co_file_url.white(),
+                "contains an empty team".yellow(),
+                team.white(),
+            ),
+            CodeownersFileProblem::UserNotInOrg { user, co_file_url } => {
+                format!(
+                    "{} {} {} {} {}",
+                    "Error in CODEOWNERS file".red(),
+                    co_file_url.white(),
+                    "User".red(),
+                    user.white(),
+                    "is not in the org".red()
+                )
+            }
+            CodeownersFileProblem::TeamNotInOrg { team, co_file_url } => {
+                format!(
+                    "{} {} {} {} {}",
+                    "Error in CODEOWNERS file".red(),
+                    co_file_url.white(),
+                    "Team".red(),
+                    team.white(),
+                    "is not in the org".red()
+                )
+            }
+        };
+        write!(f, "{msg}")
+    }
 }
 
 /// Run the audit on CODEOWNERS files to determine
@@ -33,19 +121,24 @@ pub fn run_codeowners_audit(
     repos: Option<Vec<String>>,
     search: bool,
     also_gh_api: bool,
+    verbose: bool,
 ) {
     // Immediately stop if we received incompatible options
     if search && repos.is_some() {
         panic!("{}", "Using --search assumes an org-wide search, and it is not supported in conjunction with a list of repos (i.e., --repos).".red());
     }
 
-    println!("{}", "Searching for CODEOWNERS files...".yellow());
+    println!("{}", "I am fetching CODEOWNERS files...".yellow());
 
     // Build a list of CO files we will audit
     let codeowners_files = match search {
         true => search::find_codeowners_in_org(&bootstrap),
         false => iterate::find_codeowners_in_org(&bootstrap, repos.clone()),
-    };
+    }
+    .expect(&format!(
+        "{}",
+        "Error while fetching CODEOWNERS file: I cannot continue".red()
+    ));
 
     println!(
         "{} {} {}",
@@ -64,30 +157,29 @@ pub fn run_codeowners_audit(
     let org_members = get_indexed_org_members(&bootstrap);
     let org_teams = get_indexed_org_teams(&bootstrap);
 
-    audit::audit_co_files(&bootstrap, &codeowners_files, &org_members, &org_teams);
-
-    // If we were told to also use the GH API, we do it here
-    if also_gh_api {
-        println!(
-            "{}",
-            "\nNow auditing CODEOWNERS using the GH REST API...".yellow()
-        );
-        // The repos we will scan are those that were passed or (if nothing was passed)
-        // all those that we collected CO files for in the previous steps.
-        let repos = repos.unwrap_or_else(|| {
-            codeowners_files
-                .iter()
-                .map(|file| file.repo.clone())
-                .collect()
-        });
-
-        audit::audit_co_files_with_gh_api(&bootstrap, &repos);
-    }
+    audit::audit_co_files(
+        &bootstrap,
+        &codeowners_files,
+        &org_members,
+        &org_teams,
+        also_gh_api,
+        verbose,
+    );
 }
 
 /// Look for all occurrences of that team in CODEOWNERS files across the org.
 /// This is useful to estimate the impact on CODEOWNERS that removing or renaming a team would have.
-pub fn run_team_in_codeowners_audit(bootstrap: Bootstrap, team: String, search: bool) {
+pub fn run_team_in_codeowners_audit(
+    bootstrap: Bootstrap,
+    team: String,
+    repos: Option<Vec<String>>,
+    search: bool,
+) {
+    // Immediately stop if we received incompatible options
+    if search && repos.is_some() {
+        panic!("{}", "Using --search assumes an org-wide search, and it is not supported in conjunction with a list of repos (i.e., --repos).".red());
+    }
+
     println!(
         "{} {} {}",
         "Searching for occurrences of team".yellow(),
@@ -97,49 +189,6 @@ pub fn run_team_in_codeowners_audit(bootstrap: Bootstrap, team: String, search: 
     if search {
         search::find_team_in_codeowners(&bootstrap, team)
     } else {
-        iterate::find_team_in_codeowners(&bootstrap, team, None)
-    }
-}
-
-/// Process the content of a CO file and turn it into a CodeownersFile struct
-fn codeowner_content_to_obj(
-    bootstrap: &Bootstrap,
-    content: String,
-    html_url: &str,
-    repo: &str,
-) -> CodeownersFile {
-    // Get users and teams mentioned in this CODEOWNERS file
-    // Find matches that look like @something, and then decide if it's a user or a team
-    let regex = Regex::new(r"@\S+").unwrap();
-
-    let mut users = HashSet::new();
-    let mut teams = HashSet::new();
-
-    // The prefix that teams have in CO files
-    let team_prefix = format!("@{}/", bootstrap.org);
-
-    for line in content.split('\n') {
-        if line.trim().starts_with('#') {
-            // Skip comments
-            continue;
-        }
-
-        for m in regex.find_iter(line) {
-            let matched = m.as_str();
-            if matched.starts_with(&team_prefix) {
-                // It's a team
-                teams.insert(matched.trim_start_matches(&team_prefix).to_string());
-            } else {
-                // It's a user
-                users.insert(matched.trim_start_matches("@").to_string());
-            }
-        }
-    }
-
-    CodeownersFile {
-        repo: repo.to_string(),
-        url: html_url.to_string(),
-        users,
-        teams,
+        iterate::find_team_in_codeowners(&bootstrap, team, repos)
     }
 }

--- a/src/codeowners/mod.rs
+++ b/src/codeowners/mod.rs
@@ -1,3 +1,4 @@
+mod audit;
 /// Use an iterative approach, i.e., scan repos one by one
 mod iterate;
 /// Leverage the GH search API to find relevant information
@@ -5,7 +6,7 @@ mod search;
 
 use std::collections::HashSet;
 
-use crate::{make_github_request, members::get_org_members, teams::get_org_teams, Bootstrap};
+use crate::{members::get_org_members, teams::get_org_teams, Bootstrap};
 use colored::Colorize;
 use regex::Regex;
 
@@ -22,10 +23,13 @@ struct CodeownersFile {
     teams: HashSet<String>,
 }
 
-/// Run the audit on CODEOWNERS files
+/// Run the audit on CODEOWNERS files to determine
+/// * If all users mentioned in the file exist and are members of the org
+/// * If all teams mentioned in the file exist
+///
+/// We will also alert if a team is empty.
 pub fn run_codeowners_audit(
     bootstrap: Bootstrap,
-    team: Option<String>,
     repos: Option<Vec<String>>,
     search: bool,
     also_gh_api: bool,
@@ -35,164 +39,65 @@ pub fn run_codeowners_audit(
         panic!("{}", "Using --search assumes an org-wide search, and it is not supported in conjunction with a list of repos (i.e., --repos).".red());
     }
 
-    if team.is_none() {
-        // If we didn't receive a team, then we audit CODEOWNERS files to determine
-        // * If all users mentioned in the file exist and are members of the org
-        // * If all teams mentioned in the file exist
-        // We will also alert if a team is empty.
-        println!("{}", "Searching for CODEOWNERS files...".yellow());
+    println!("{}", "Searching for CODEOWNERS files...".yellow());
 
-        let codeowners_files = match search {
-            true => search::find_codeowners_in_org(&bootstrap),
-            false => iterate::find_codeowners_in_org(&bootstrap, repos.clone()),
-        };
+    // Build a list of CO files we will audit
+    let codeowners_files = match search {
+        true => search::find_codeowners_in_org(&bootstrap),
+        false => iterate::find_codeowners_in_org(&bootstrap, repos.clone()),
+    };
 
-        println!(
-            "{} {} {}",
-            "Done! I found".green(),
-            codeowners_files.len().to_string().white(),
-            "CODEOWNERS files".green()
-        );
+    println!(
+        "{} {} {}",
+        "Done! I found".green(),
+        codeowners_files.len().to_string().white(),
+        "CODEOWNERS files".green()
+    );
 
+    println!(
+        "{}",
+        "Preparing to analyze these CODEOWNERS files...".yellow()
+    );
+
+    // Get all members and teams in the org, so that we can efficiently
+    // cross-check the content of all the CODEOWNERS files we have found.
+    let org_members = get_org_members(&bootstrap);
+    let org_teams = get_org_teams(&bootstrap);
+
+    audit::audit_co_files(&bootstrap, &codeowners_files, &org_members, &org_teams);
+
+    // If we were told to also use the GH API, we do it here
+    if also_gh_api {
         println!(
             "{}",
-            "Preparing to analyze these CODEOWNERS files...".yellow()
+            "\nNow auditing CODEOWNERS using the GH REST API...".yellow()
         );
+        // The repos we will scan are those that were passed or (if nothing was passed)
+        // all those that we collected CO files for in the previous steps.
+        let repos = repos.unwrap_or_else(|| {
+            codeowners_files
+                .iter()
+                .map(|file| file.repo.clone())
+                .collect()
+        });
 
-        // Get all members and teams in the org, so that we can efficiently
-        // cross-check the content of all the CODEOWNERS files we have found.
-        let org_members = get_org_members(&bootstrap);
-        let org_teams = get_org_teams(&bootstrap);
+        audit::audit_co_files_with_gh_api(&bootstrap, &repos);
+    }
+}
 
-        // Keep a growing cache of empty and non-empty teams to make checks more efficient.
-        let mut non_empty_teams = HashSet::<String>::new();
-        let mut empty_teams = HashSet::<String>::new();
-
-        // Analyze each CO file we found
-        for co_file in &codeowners_files {
-            let mut no_errors = true;
-
-            // Check if all the users mentioned in the CO file are in the org
-            for user in &co_file.users {
-                if org_members.iter().find(|u| u.login == *user).is_none() {
-                    no_errors = false;
-                    println!(
-                        "{} {} {} {} {}",
-                        "Error in CODEOWNERS file".red(),
-                        co_file.url.white(),
-                        "User".red(),
-                        user.white(),
-                        "does not belong to the org".red()
-                    );
-                }
-            }
-
-            // Check if all the teams mentioned in the CO file exist and alert if a team is empty.
-            for team in &co_file.teams {
-                match org_teams.iter().find(|t| t.slug == *team) {
-                    None => {
-                        no_errors = false;
-                        println!(
-                            "{} {} {} {} {}",
-                            "Error in CODEOWNERS file".red(),
-                            co_file.url.white(),
-                            "Team".red(),
-                            team.white(),
-                            "does not exist in the org".red()
-                        );
-                    }
-                    Some(t) => {
-                        // Check if the team is empty, by first looking into the cache: if
-                        // it's not there, we call GH API and update the cache accordingly.
-                        // Note - the || operator short-circuits, so we are making the call to GH API
-                        // only if the team is not in our cache.
-                        if empty_teams.contains(&t.slug) || t.is_empty(&bootstrap) {
-                            no_errors = false;
-                            println!(
-                                "{} {} {} {}",
-                                "Warning! CODEOWNERS file".red(),
-                                co_file.url.white(),
-                                "contains an empty team:".red(),
-                                t.slug.white(),
-                            );
-                            empty_teams.insert(t.slug.clone());
-                        } else {
-                            // The team is not empty. Let's insert it into the non-empty cache (repeated
-                            // insertions don't matter because it's a HashSet).
-                            non_empty_teams.insert(t.slug.clone());
-                        }
-                    }
-                }
-            }
-
-            if no_errors {
-                println!(
-                    "{} {}",
-                    "No errors detected in CODEOWNERS file for repo".green(),
-                    co_file.repo.white()
-                );
-            }
-        }
-
-        // If we were told to also use the GH API, we do it here
-        if also_gh_api {
-            println!(
-                "{}",
-                "\nNow auditing CODEOWNERS using the GH REST API...".yellow()
-            );
-            // The repos we will scan are those that were passed or (if nothing was passed)
-            // all those that we collected CO files for in the previous steps.
-            let repos = repos.unwrap_or_else(|| {
-                codeowners_files
-                    .iter()
-                    .map(|file| file.repo.clone())
-                    .collect()
-            });
-            for repo in repos {
-                // Call the GH API
-                match get_codeowners_errors(&bootstrap, &repo) {
-                    Ok(kinds) => {
-                        if kinds.is_empty() {
-                            println!(
-                                "{} {}",
-                                "No errors detected in CODEOWNERS file for repo".green(),
-                                repo.white()
-                            );
-                        } else {
-                            println!(
-                                "{} {}: {:?}",
-                                "Errors detected in CODEOWNERS file for repo".red(),
-                                repo.white(),
-                                kinds
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        println!(
-                            "{} {} {} {}",
-                            "Warning!".yellow(),
-                            e.white(),
-                            "for repo".yellow(),
-                            repo.white()
-                        );
-                    }
-                }
-            }
-        }
+/// Look for all occurrences of that team in CODEOWNERS files across the org.
+/// This is useful to estimate the impact on CODEOWNERS that removing or renaming a team would have.
+pub fn run_team_in_codeowners_audit(bootstrap: Bootstrap, team: String, search: bool) {
+    println!(
+        "{} {} {}",
+        "Searching for occurrences of team".yellow(),
+        team.white(),
+        "in CODEOWNERS files...".yellow()
+    );
+    if search {
+        search::find_team_in_codeowners(&bootstrap, team)
     } else {
-        // If we do receive a team, then we will look for all occurrences of that team in CODEOWNERS files across the org.
-        // This is useful to estimate the impact on CODEOWNERS that removing or renaming a team would have.
-        let team = team.unwrap();
-        println!(
-            "{} {} {}",
-            "Searching for occurrences of team".yellow(),
-            team.white(),
-            "in CODEOWNERS files...".yellow()
-        );
-        match search {
-            true => search::find_team_in_codeowners(&bootstrap, team),
-            false => iterate::find_team_in_codeowners(&bootstrap, team, repos),
-        }
+        iterate::find_team_in_codeowners(&bootstrap, team, None)
     }
 }
 
@@ -214,7 +119,7 @@ fn codeowner_content_to_obj(
     let team_prefix = format!("@{}/", bootstrap.org);
 
     for line in content.split('\n') {
-        if line.starts_with('#') {
+        if line.trim().starts_with('#') {
             // Skip comments
             continue;
         }
@@ -236,26 +141,5 @@ fn codeowner_content_to_obj(
         url: html_url.to_string(),
         users,
         teams,
-    }
-}
-
-/// Call the GH API and retrieve errors detected in the CODEOWNERS file.
-fn get_codeowners_errors(bootstrap: &Bootstrap, repo: &str) -> Result<Vec<String>, String> {
-    let url = format!("/repos/{}/{repo}/codeowners/errors", bootstrap.org);
-    let res = make_github_request(&bootstrap.token, &url, 3, None).unwrap();
-    match res.get("errors") {
-        None => {
-            // If this field is not present, it means a CO file has not been found
-            return Err("CODEOWNERS file not found".to_string());
-        }
-        Some(errors) => {
-            let kinds: Vec<String> = errors
-                .as_array()
-                .unwrap()
-                .iter()
-                .map(|e| e.get("kind").unwrap().as_str().unwrap().to_string())
-                .collect();
-            Ok(kinds)
-        }
     }
 }

--- a/src/codeowners/mod.rs
+++ b/src/codeowners/mod.rs
@@ -6,7 +6,7 @@ mod search;
 
 use std::collections::HashSet;
 
-use crate::{members::get_org_members, teams::get_org_teams, Bootstrap};
+use crate::{members::get_indexed_org_members, teams::get_indexed_org_teams, Bootstrap};
 use colored::Colorize;
 use regex::Regex;
 
@@ -61,8 +61,8 @@ pub fn run_codeowners_audit(
 
     // Get all members and teams in the org, so that we can efficiently
     // cross-check the content of all the CODEOWNERS files we have found.
-    let org_members = get_org_members(&bootstrap);
-    let org_teams = get_org_teams(&bootstrap);
+    let org_members = get_indexed_org_members(&bootstrap);
+    let org_teams = get_indexed_org_teams(&bootstrap);
 
     audit::audit_co_files(&bootstrap, &codeowners_files, &org_members, &org_teams);
 

--- a/src/codeowners/search.rs
+++ b/src/codeowners/search.rs
@@ -40,7 +40,9 @@ pub fn find_codeowners_in_org(bootstrap: &Bootstrap) -> Vec<CodeownersFile> {
             let api_url = item.get("url").unwrap().as_str().unwrap();
             let content = crate::utils::fetch_file_content(&bootstrap, api_url);
 
-            all_results.push(codeowner_content_to_obj(bootstrap, content, html_url, repo));
+            if let Some(content) = content {
+                all_results.push(codeowner_content_to_obj(bootstrap, content, html_url, repo));
+            }
         }
         page += 1;
     }

--- a/src/codeowners/search.rs
+++ b/src/codeowners/search.rs
@@ -2,10 +2,10 @@ use colored::Colorize;
 
 use crate::{make_github_request, Bootstrap};
 
-use super::{codeowner_content_to_obj, CodeownersFile};
+use super::CodeownersFile;
 
 /// Find all the codeowners files in an organization
-pub fn find_codeowners_in_org(bootstrap: &Bootstrap) -> Vec<CodeownersFile> {
+pub fn find_codeowners_in_org(bootstrap: &Bootstrap) -> Result<Vec<CodeownersFile>, String> {
     let query = format!("org:{} filename:CODEOWNERS", bootstrap.org);
     let query = urlencoding::encode(&query).to_string();
 
@@ -16,38 +16,49 @@ pub fn find_codeowners_in_org(bootstrap: &Bootstrap) -> Vec<CodeownersFile> {
         // !!! NOTE - This endpoint has a custom rate limitation !!!
         // https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#rate-limit
         let address = format!("/search/code?q={query}&per_page=100&page={page}");
-        let res = make_github_request(&bootstrap.token, &address, 3, None).unwrap();
-        let items = res.get("items").unwrap().as_array().unwrap();
+        let res = make_github_request(&bootstrap.token, &address, 3, None)?;
+        let items = res
+            .get("items")
+            .and_then(|i| i.as_array())
+            .and_then(|a| Some(a.clone()))
+            .unwrap_or_default();
         if items.is_empty() {
             // We are past the last page
             break;
         }
         for item in items {
             // Filter out all files that are not called exactly CODEOWNERS
-            let name = item.get("name").unwrap().as_str().unwrap();
+            let name = item
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("Not available");
             if name != "CODEOWNERS" {
                 continue;
             }
 
             let repo = item
                 .get("repository")
-                .unwrap()
-                .get("name")
-                .unwrap()
-                .as_str()
-                .unwrap();
-            let html_url = item.get("html_url").unwrap().as_str().unwrap();
-            let api_url = item.get("url").unwrap().as_str().unwrap();
-            let content = crate::utils::fetch_file_content(&bootstrap, api_url);
-
-            if let Some(content) = content {
-                all_results.push(codeowner_content_to_obj(bootstrap, content, html_url, repo));
+                .and_then(|r| r.get("name"))
+                .and_then(|n| n.as_str())
+                .unwrap_or("Not available");
+            let html_url = item
+                .get("html_url")
+                .and_then(|u| u.as_str())
+                .unwrap_or("Not available");
+            let api_url = item
+                .get("url")
+                .and_then(|u| u.as_str())
+                .unwrap_or("Not available");
+            if let Ok(content) = crate::utils::fetch_file_content(&bootstrap, api_url) {
+                all_results.push(CodeownersFile::parse_from_content(
+                    bootstrap, content, html_url, repo,
+                ));
             }
         }
         page += 1;
     }
 
-    all_results
+    Ok(all_results)
 }
 
 /// Find all occurrences of a given team in an organization's codeowners files
@@ -65,25 +76,33 @@ pub fn find_team_in_codeowners(bootstrap: &Bootstrap, team: String) {
         // https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#rate-limit
         let address = format!("/search/code?q={query}&per_page=100&page={page}");
         let res = make_github_request(&bootstrap.token, &address, 3, None).unwrap();
-        let items = res.get("items").unwrap().as_array().unwrap();
+        let items = res
+            .get("items")
+            .and_then(|i| i.as_array())
+            .and_then(|a| Some(a.clone()))
+            .unwrap_or_default();
         if items.is_empty() {
             break;
         }
         for item in items {
             // Filter out all files that are not called exactly CODEOWNERS
-            let name = item.get("name").unwrap().as_str().unwrap();
+            let name = item
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("Not available");
             if name != "CODEOWNERS" {
                 continue;
             }
 
             let repo = item
                 .get("repository")
-                .unwrap()
-                .get("name")
-                .unwrap()
-                .as_str()
-                .unwrap();
-            let html_url = item.get("html_url").unwrap().as_str().unwrap();
+                .and_then(|r| r.get("name"))
+                .and_then(|n| n.as_str())
+                .unwrap_or("Not available");
+            let html_url = item
+                .get("html_url")
+                .and_then(|u| u.as_str())
+                .unwrap_or("Not available");
 
             println!(
                 "{} {:<50} - {} {}",

--- a/src/codeowners/search.rs
+++ b/src/codeowners/search.rs
@@ -1,0 +1,96 @@
+use colored::Colorize;
+
+use crate::{make_github_request, Bootstrap};
+
+use super::{codeowner_content_to_obj, CodeownersFile};
+
+/// Find all the codeowners files in an organization
+pub fn find_codeowners_in_org(bootstrap: &Bootstrap) -> Vec<CodeownersFile> {
+    let query = format!("org:{} filename:CODEOWNERS", bootstrap.org);
+    let query = urlencoding::encode(&query).to_string();
+
+    let mut page = 1;
+    let mut all_results = vec![];
+
+    loop {
+        // !!! NOTE - This endpoint has a custom rate limitation !!!
+        // https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#rate-limit
+        let address = format!("/search/code?q={query}&per_page=100&page={page}");
+        let res = make_github_request(&bootstrap.token, &address, 3, None).unwrap();
+        let items = res.get("items").unwrap().as_array().unwrap();
+        if items.is_empty() {
+            // We are past the last page
+            break;
+        }
+        for item in items {
+            // Filter out all files that are not called exactly CODEOWNERS
+            let name = item.get("name").unwrap().as_str().unwrap();
+            if name != "CODEOWNERS" {
+                continue;
+            }
+
+            let repo = item
+                .get("repository")
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap();
+            let html_url = item.get("html_url").unwrap().as_str().unwrap();
+            let api_url = item.get("url").unwrap().as_str().unwrap();
+            let content = crate::utils::fetch_file_content(&bootstrap, api_url);
+
+            all_results.push(codeowner_content_to_obj(bootstrap, content, html_url, repo));
+        }
+        page += 1;
+    }
+
+    all_results
+}
+
+/// Find all occurrences of a given team in an organization's codeowners files
+pub fn find_team_in_codeowners(bootstrap: &Bootstrap, team: String) {
+    let query = format!(
+        "org:{} filename:CODEOWNERS @{}/{}",
+        bootstrap.org, bootstrap.org, team
+    );
+    let query = urlencoding::encode(&query).to_string();
+
+    let mut page = 1;
+
+    loop {
+        // !!! NOTE - This endpoint has a custom rate limitation !!!
+        // https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#rate-limit
+        let address = format!("/search/code?q={query}&per_page=100&page={page}");
+        let res = make_github_request(&bootstrap.token, &address, 3, None).unwrap();
+        let items = res.get("items").unwrap().as_array().unwrap();
+        if items.is_empty() {
+            break;
+        }
+        for item in items {
+            // Filter out all files that are not called exactly CODEOWNERS
+            let name = item.get("name").unwrap().as_str().unwrap();
+            if name != "CODEOWNERS" {
+                continue;
+            }
+
+            let repo = item
+                .get("repository")
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap();
+            let html_url = item.get("html_url").unwrap().as_str().unwrap();
+
+            println!(
+                "{} {:<50} - {} {}",
+                "Repository:".yellow(),
+                repo.white(),
+                "URL:".yellow(),
+                html_url.white()
+            )
+        }
+        page += 1;
+    }
+}

--- a/src/external_collaborator.rs
+++ b/src/external_collaborator.rs
@@ -149,7 +149,18 @@ pub fn run_audit(bootstrap: Bootstrap, previous_csv: Option<String>) {
     let mut ec_permissions = ExternalCollaboratorPermissions::new();
 
     for repository in repositories {
-        let collaborators = get_repo_collaborators(&bootstrap, &repository.name);
+        let collaborators = match get_repo_collaborators(&bootstrap, &repository.name) {
+            Ok(c) => c,
+            Err(_) => {
+                println!(
+                    "{} {} {}",
+                    "I couldn't fetch collaborators for repository".yellow(),
+                    repository.name.white(),
+                    ". I will continue with other repositories.".yellow()
+                );
+                continue;
+            }
+        };
 
         for collaborator in collaborators {
             if outside_collaborators.contains_key(&collaborator.login) {

--- a/src/external_collaborator.rs
+++ b/src/external_collaborator.rs
@@ -6,8 +6,8 @@ use std::{
 use colored::Colorize;
 
 use crate::{
-    make_paginated_github_request, make_paginated_github_request_with_index, Bootstrap,
-    Collaborator, GitHubIndex, Repository,
+    get_repo_collaborators, make_paginated_github_request_with_index, Bootstrap, GitHubIndex,
+    Repository,
 };
 
 pub type ExternalCollaboratorPermissions =
@@ -149,25 +149,7 @@ pub fn run_audit(bootstrap: Bootstrap, previous_csv: Option<String>) {
     let mut ec_permissions = ExternalCollaboratorPermissions::new();
 
     for repository in repositories {
-        let collaborators: HashSet<Collaborator> = match make_paginated_github_request(
-            &bootstrap.token,
-            25,
-            &format!(
-                "/repos/{}/{}/collaborators",
-                &bootstrap.org, repository.name
-            ),
-            3,
-            None,
-        ) {
-            Ok(collaborators) => collaborators,
-            Err(e) => {
-                panic!(
-                    "{} {}: {e}",
-                    repository.name.white(),
-                    "I couldn't fetch the repository collaborators".red()
-                );
-            }
-        };
+        let collaborators = get_repo_collaborators(&bootstrap, &repository.name);
 
         for collaborator in collaborators {
             if outside_collaborators.contains_key(&collaborator.login) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ fn get_repo_teams(bootstrap: &Bootstrap, repo: &str) -> HashSet<TeamWithPermissi
             panic!(
                 "{} {}: {e}",
                 repo.white(),
-                "I couldn't fetch the repository collaborators".red()
+                "I couldn't fetch teams with access to the repo".red()
             );
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,6 @@ impl Permissions {
         }
         "none".to_string()
     }
-
-    /*/// Return whether the permission is Write or higher
-    fn write_or_higher(&self) -> bool {
-        ["admin", "maintain", "push"].contains(&self.highest_perm().as_str())
-    }*/
 }
 
 #[derive(Debug, serde::Deserialize, Hash, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,12 @@ pub struct Team {
     pub permissions: Option<Permissions>,
 }
 
+impl GitHubIndex for Team {
+    fn index(&self) -> String {
+        self.slug.clone()
+    }
+}
+
 impl Team {
     /// Return whether a team is empty, i.e., if the team has no members,
     /// including its sub-teams.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,13 +95,7 @@ pub struct Repository {
 pub struct Team {
     pub name: String,
     pub slug: String,
-}
-
-#[derive(serde::Deserialize, Hash, Eq, PartialEq)]
-pub struct TeamWithPermissions {
-    pub name: String,
-    pub slug: String,
-    pub permissions: Permissions,
+    pub permissions: Option<Permissions>,
 }
 
 impl Team {
@@ -435,8 +429,8 @@ fn get_repo_collaborators(bootstrap: &Bootstrap, repo: &str) -> HashSet<Collabor
 }
 
 /// Get the teams that have access to the repo
-fn get_repo_teams(bootstrap: &Bootstrap, repo: &str) -> HashSet<TeamWithPermissions> {
-    let repo_teams: HashSet<TeamWithPermissions> = match make_paginated_github_request(
+fn get_repo_teams(bootstrap: &Bootstrap, repo: &str) -> HashSet<Team> {
+    let repo_teams: HashSet<Team> = match make_paginated_github_request(
         &bootstrap.token,
         25,
         &format!("/repos/{}/{}/teams", &bootstrap.org, repo),

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,10 @@ struct Args {
     #[arg(short, long)]
     codeowners: bool,
 
+    /// Find occurrences of a team in CODEOWNERS files
+    #[arg(long)]
+    team_in_codeowners: bool,
+
     /// Also invoke the GH API to get extra info when auditing CODEOWNERS
     #[arg(long)]
     also_gh_api: bool,
@@ -99,13 +103,13 @@ fn main() {
     } else if args.emptyteams {
         teams::run_empty_teams_audit(bootstrap);
     } else if args.codeowners {
-        codeowners::run_codeowners_audit(
-            bootstrap,
-            args.team,
-            args.repos,
-            args.search,
-            args.also_gh_api,
-        );
+        codeowners::run_codeowners_audit(bootstrap, args.repos, args.search, args.also_gh_api);
+    } else if args.team_in_codeowners {
+        if let Some(team) = args.team {
+            codeowners::run_team_in_codeowners_audit(bootstrap, team, args.search);
+        } else {
+            println!("Please specify a team with --team");
+        }
     } else {
         println!("No command specified");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,10 @@ struct Args {
     /// The previous run CSV file
     #[arg(short, long)]
     previous: Option<String>,
+
+    /// Increase verbosity
+    #[arg(short, long)]
+    verbose: bool,
 }
 
 fn main() {
@@ -103,10 +107,16 @@ fn main() {
     } else if args.emptyteams {
         teams::run_empty_teams_audit(bootstrap);
     } else if args.codeowners {
-        codeowners::run_codeowners_audit(bootstrap, args.repos, args.search, args.also_gh_api);
+        codeowners::run_codeowners_audit(
+            bootstrap,
+            args.repos,
+            args.search,
+            args.also_gh_api,
+            args.verbose,
+        );
     } else if args.team_in_codeowners {
         if let Some(team) = args.team {
-            codeowners::run_team_in_codeowners_audit(bootstrap, team, args.search);
+            codeowners::run_team_in_codeowners_audit(bootstrap, team, args.repos, args.search);
         } else {
             println!("Please specify a team with --team");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,10 @@ struct Args {
     #[arg(short, long)]
     codeowners: bool,
 
+    /// Also invoke the GH API to get extra info when auditing CODEOWNERS
+    #[arg(long)]
+    also_gh_api: bool,
+
     /// Focus the audit on a given GH team
     #[arg(long)]
     team: Option<String>,
@@ -95,7 +99,13 @@ fn main() {
     } else if args.emptyteams {
         teams::run_empty_teams_audit(bootstrap);
     } else if args.codeowners {
-        codeowners::run_codeowners_audit(bootstrap, args.team, args.repos, args.search);
+        codeowners::run_codeowners_audit(
+            bootstrap,
+            args.team,
+            args.repos,
+            args.search,
+            args.also_gh_api,
+        );
     } else {
         println!("No command specified");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use gh_ec_audit::deploy_key;
 use gh_ec_audit::external_collaborator;
 
 use clap::{command, Parser};
+use gh_ec_audit::codeowners;
 use gh_ec_audit::members;
 use gh_ec_audit::teams;
 use gh_ec_audit::Bootstrap;
@@ -39,12 +40,21 @@ struct Args {
     #[arg(long)]
     emptyteams: bool,
 
+    /// Run the CODEOWNERS audit
+    #[arg(short, long)]
+    codeowners: bool,
+
+    /// Focus the audit on a given GH team
     #[arg(long)]
     team: Option<String>,
 
-    // Disable filtering on specific audits
+    /// Disable filtering on specific audits
     #[clap(long, default_value_t = false)]
     all: bool,
+
+    /// Use GH search API instead of enumerating repos (only for specific audits)
+    #[clap(long, default_value_t = false)]
+    search: bool,
 
     /// Limit the scanning to the given repos
     #[clap(short, long, value_delimiter = ',', num_args = 1..)]
@@ -84,6 +94,8 @@ fn main() {
         }
     } else if args.emptyteams {
         teams::run_empty_teams_audit(bootstrap);
+    } else if args.codeowners {
+        codeowners::run_codeowners_audit(bootstrap, args.team, args.repos, args.search);
     } else {
         println!("No command specified");
     }

--- a/src/members.rs
+++ b/src/members.rs
@@ -7,21 +7,23 @@ use crate::{
     Collaborator, Member, Permissions, Repository,
 };
 
-pub fn run_audit(bootstrap: Bootstrap) {
-    let members: HashSet<Member> = match make_paginated_github_request(
+pub fn get_org_members(bootstrap: &Bootstrap) -> HashSet<Member> {
+    match make_paginated_github_request(
         &bootstrap.token,
         100,
         &format!("/orgs/{}/members", &bootstrap.org),
         3,
         None,
     ) {
-        Ok(outside_collaborators) => outside_collaborators,
+        Ok(mem) => mem,
         Err(e) => {
             panic!("{}: {e}", "I couldn't fetch the organization members".red());
         }
-    };
+    }
+}
 
-    for member in members {
+pub fn run_audit(bootstrap: Bootstrap) {
+    for member in get_org_members(&bootstrap) {
         println!("{}", member.avatar_url);
     }
 }

--- a/src/members.rs
+++ b/src/members.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 
 use crate::{
     get_repo_teams, make_paginated_github_request, make_paginated_github_request_with_index,
-    Bootstrap, Collaborator, Member, Permissions, Repository, TeamWithPermissions,
+    Bootstrap, Collaborator, Member, Permissions, Repository, Team,
 };
 
 pub fn get_org_members(bootstrap: &Bootstrap) -> HashSet<Member> {
@@ -72,8 +72,8 @@ pub fn run_admin_audit(bootstrap: Bootstrap, repos: Option<Vec<String>>) {
 
         let repo_admin_teams = repo_teams
             .iter()
-            .filter(|t| t.permissions.admin)
-            .collect::<Vec<&TeamWithPermissions>>();
+            .filter(|t| t.permissions.as_ref().unwrap().admin)
+            .collect::<Vec<&Team>>();
 
         for repo_admin_team in &repo_admin_teams {
             println!(

--- a/src/members.rs
+++ b/src/members.rs
@@ -83,7 +83,18 @@ pub fn run_admin_audit(bootstrap: Bootstrap, repos: Option<Vec<String>>) {
 
     for repository in repositories {
         // Get the teams that have access to the repository
-        let repo_teams = get_repo_teams(&bootstrap, &repository.name);
+        let repo_teams = match get_repo_teams(&bootstrap, &repository.name) {
+            Ok(rt) => rt,
+            Err(_) => {
+                println!(
+                    "{} {} {}",
+                    "I couldn't fetch teams with access to repository".yellow(),
+                    repository.name.white(),
+                    ". I will continue with other repositories.".yellow()
+                );
+                continue;
+            }
+        };
 
         let repo_admin_teams = repo_teams
             .iter()

--- a/src/members.rs
+++ b/src/members.rs
@@ -22,6 +22,21 @@ pub fn get_org_members(bootstrap: &Bootstrap) -> HashSet<Member> {
     }
 }
 
+pub fn get_indexed_org_members(bootstrap: &Bootstrap) -> HashMap<String, Member> {
+    match make_paginated_github_request_with_index(
+        &bootstrap.token,
+        100,
+        &format!("/orgs/{}/members", &bootstrap.org),
+        3,
+        None,
+    ) {
+        Ok(mem) => mem,
+        Err(e) => {
+            panic!("{}: {e}", "I couldn't fetch the organization members".red());
+        }
+    }
+}
+
 pub fn run_audit(bootstrap: Bootstrap) {
     for member in get_org_members(&bootstrap) {
         println!("{}", member.avatar_url);

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use colored::Colorize;
 
-use crate::{make_github_request, make_paginated_github_request, Bootstrap, Repository, Team};
+use crate::{make_paginated_github_request, Bootstrap, Repository, Team};
 
 /// Returns the repos that a team has access to
 fn get_team_repos(bootstrap: &Bootstrap, team: String) -> HashSet<Repository> {
@@ -41,13 +41,8 @@ pub fn run_team_repo_audit(bootstrap: Bootstrap, team: String) {
     }
 }
 
-/// Fetch all empty teams, i.e., teams with no members
-pub fn run_empty_teams_audit(bootstrap: Bootstrap) {
-    println!(
-        "{}",
-        "I am going to fetch all teams from the org...".yellow()
-    );
-    // Get a list of all teams in the org
+/// Get a list of all teams in the org
+pub fn get_org_teams(bootstrap: &Bootstrap) -> HashSet<Team> {
     let teams: HashSet<Team> = match make_paginated_github_request(
         &bootstrap.token,
         25,
@@ -63,6 +58,18 @@ pub fn run_empty_teams_audit(bootstrap: Bootstrap) {
             );
         }
     };
+
+    teams
+}
+
+/// Fetch all empty teams, i.e., teams with no members
+pub fn run_empty_teams_audit(bootstrap: Bootstrap) {
+    println!(
+        "{}",
+        "I am going to fetch all teams from the org...".yellow()
+    );
+    let teams = get_org_teams(&bootstrap);
+
     println!(
         "{} {} {}",
         "Done: I found".green(),
@@ -71,33 +78,9 @@ pub fn run_empty_teams_audit(bootstrap: Bootstrap) {
     );
     println!("{}", "Now I will check for empty teams...".yellow());
 
-    // For each team, get a list of its members and see if it's empty.
-    // NOTE - We don't make a paginated request on purpose: we only want
-    // to see if a team is empty or not. As soon as we have some members,
-    // we want to move to the next team instead of fetching _all_ members.
+    // For each team, see if it's empty.
     for team in teams {
-        let members = match make_github_request(
-            &bootstrap.token,
-            &format!("/orgs/{}/teams/{}/members", bootstrap.org, team.slug),
-            3,
-            None,
-        ) {
-            Ok(members) => members,
-            Err(e) => {
-                panic!(
-                    "{} {}: {}",
-                    "I couldn't fetch the members of team".red(),
-                    team.name,
-                    e
-                );
-            }
-        };
-        let members = members.as_array().expect(&format!(
-            "{}",
-            "The value returned by GH is not an array".red()
-        ));
-
-        if members.is_empty() {
+        if team.is_empty(&bootstrap) {
             // The team is empty: we want to see to how many repos it has access
             let team_repos = get_team_repos(&bootstrap, team.slug);
             println!(

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -1,8 +1,11 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use colored::Colorize;
 
-use crate::{make_paginated_github_request, Bootstrap, Repository, Team};
+use crate::{
+    make_paginated_github_request, make_paginated_github_request_with_index, Bootstrap, Repository,
+    Team,
+};
 
 /// Returns the repos that a team has access to
 fn get_team_repos(bootstrap: &Bootstrap, team: String) -> HashSet<Repository> {
@@ -43,7 +46,7 @@ pub fn run_team_repo_audit(bootstrap: Bootstrap, team: String) {
 
 /// Get a list of all teams in the org
 pub fn get_org_teams(bootstrap: &Bootstrap) -> HashSet<Team> {
-    let teams: HashSet<Team> = match make_paginated_github_request(
+    match make_paginated_github_request(
         &bootstrap.token,
         25,
         &format!("/orgs/{}/teams", &bootstrap.org),
@@ -57,9 +60,26 @@ pub fn get_org_teams(bootstrap: &Bootstrap) -> HashSet<Team> {
                 "I couldn't fetch the list of teams in the org".red()
             );
         }
-    };
+    }
+}
 
-    teams
+/// Get a list of all teams in the org, indexed by the team slug
+pub fn get_indexed_org_teams(bootstrap: &Bootstrap) -> HashMap<String, Team> {
+    match make_paginated_github_request_with_index(
+        &bootstrap.token,
+        25,
+        &format!("/orgs/{}/teams", &bootstrap.org),
+        3,
+        None,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            panic!(
+                "{}: {e}",
+                "I couldn't fetch the list of teams in the org".red()
+            );
+        }
+    }
 }
 
 /// Fetch all empty teams, i.e., teams with no members

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -100,7 +100,7 @@ pub fn run_empty_teams_audit(bootstrap: Bootstrap) {
 
     // For each team, see if it's empty.
     for team in teams {
-        if team.is_empty(&bootstrap) {
+        if let Ok(true) = team.is_empty(&bootstrap) {
             // The team is empty: we want to see to how many repos it has access
             let team_repos = get_team_repos(&bootstrap, team.slug);
             println!(
@@ -110,6 +110,13 @@ pub fn run_empty_teams_audit(bootstrap: Bootstrap) {
                 "This team has access to".yellow(),
                 team_repos.len().to_string().white(),
                 "repositories".yellow()
+            );
+        } else {
+            println!(
+                "{} {} {}",
+                "Warning! I could not determine if team".yellow(),
+                team.slug.white(),
+                "is empty. I will continue with other teams.".yellow()
             );
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,28 +1,28 @@
 use crate::{make_github_request, Bootstrap};
 use base64::prelude::*;
-use colored::Colorize;
 use serde_json::Value;
 
 /// Retrieve the content of a GH file
-pub fn fetch_file_content(bootstrap: &Bootstrap, url: &str) -> Option<String> {
+pub fn fetch_file_content(bootstrap: &Bootstrap, url: &str) -> Result<String, String> {
     let url = url.trim_start_matches("https://api.github.com");
     let res = make_github_request(&bootstrap.token, url, 3, None).unwrap();
     process_fetch_file_result(res)
 }
 
 /// Process the result of fetching a file from GH and return its content
-pub fn process_fetch_file_result(res: Value) -> Option<String> {
-    let type_ = res.get("type").unwrap().as_str().unwrap();
-    let encoding = res.get("encoding").unwrap().as_str().unwrap();
+pub fn process_fetch_file_result(res: Value) -> Result<String, String> {
+    let type_ = res
+        .get("type")
+        .and_then(|t| t.as_str())
+        .unwrap_or("Not available");
+    let encoding = res
+        .get("encoding")
+        .and_then(|e| e.as_str())
+        .unwrap_or("Not available");
     if type_ != "file" || encoding != "base64" {
-        println!(
-            "{} {} {} {}",
-            "Error while fetching content from GitHub. Got type:".red(),
-            type_.white(),
-            ", encoding:".red(),
-            encoding.white()
-        );
-        return None;
+        return Err(format!(
+            "Unexpected type or encoding while fetching file from GitHub: got type [{type_}] and encoding [{encoding}]"
+        ));
     }
     let content = res
         .get("content")
@@ -30,18 +30,12 @@ pub fn process_fetch_file_result(res: Value) -> Option<String> {
         .and_then(|s| Some(s.trim().replace("\n", "")));
 
     if let Some(content) = content {
-        // base64-decode the content
-        let content = BASE64_STANDARD.decode(&content).expect(&format!(
-            "{} [{}]",
-            "Error while base64-decoding file content:".red(),
-            content.white()
-        ));
-        Some(String::from_utf8(content).unwrap())
+        // base64-decode the content and return the string
+        BASE64_STANDARD
+            .decode(&content)
+            .map_err(|e| format!("Error while base64 decoding: {e}"))
+            .and_then(|d| String::from_utf8(d).map_err(|e| format!("The content is not UTF8: {e}")))
     } else {
-        println!(
-            "{}",
-            "Something went wrong while retrieving a file's content from GH".red()
-        );
-        None
+        Err("Error while retrieving a file's content from GitHub".to_string())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,37 +4,44 @@ use colored::Colorize;
 use serde_json::Value;
 
 /// Retrieve the content of a GH file
-pub fn fetch_file_content(bootstrap: &Bootstrap, url: &str) -> String {
+pub fn fetch_file_content(bootstrap: &Bootstrap, url: &str) -> Option<String> {
     let url = url.trim_start_matches("https://api.github.com");
     let res = make_github_request(&bootstrap.token, url, 3, None).unwrap();
     process_fetch_file_result(res)
 }
 
 /// Process the result of fetching a file from GH and return its content
-pub fn process_fetch_file_result(res: Value) -> String {
+pub fn process_fetch_file_result(res: Value) -> Option<String> {
     let type_ = res.get("type").unwrap().as_str().unwrap();
     let encoding = res.get("encoding").unwrap().as_str().unwrap();
     if type_ != "file" || encoding != "base64" {
-        panic!(
+        println!(
             "{} {} {} {}",
             "Error while fetching content from GitHub. Got type:".red(),
             type_.white(),
             ", encoding:".red(),
             encoding.white()
-        )
+        );
+        return None;
     }
     let content = res
         .get("content")
-        .unwrap()
-        .as_str()
-        .unwrap()
-        .trim()
-        .replace("\n", "");
-    // base64-decode the content
-    let content = BASE64_STANDARD.decode(&content).expect(&format!(
-        "{} [{}]",
-        "Error while base64-decoding file content:".red(),
-        content.white()
-    ));
-    String::from_utf8(content).unwrap()
+        .and_then(|v| v.as_str())
+        .and_then(|s| Some(s.trim().replace("\n", "")));
+
+    if let Some(content) = content {
+        // base64-decode the content
+        let content = BASE64_STANDARD.decode(&content).expect(&format!(
+            "{} [{}]",
+            "Error while base64-decoding file content:".red(),
+            content.white()
+        ));
+        Some(String::from_utf8(content).unwrap())
+    } else {
+        println!(
+            "{}",
+            "Something went wrong while retrieving a file's content from GH".red()
+        );
+        None
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,40 @@
+use crate::{make_github_request, Bootstrap};
+use base64::prelude::*;
+use colored::Colorize;
+use serde_json::Value;
+
+/// Retrieve the content of a GH file
+pub fn fetch_file_content(bootstrap: &Bootstrap, url: &str) -> String {
+    let url = url.trim_start_matches("https://api.github.com");
+    let res = make_github_request(&bootstrap.token, url, 3, None).unwrap();
+    process_fetch_file_result(res)
+}
+
+/// Process the result of fetching a file from GH and return its content
+pub fn process_fetch_file_result(res: Value) -> String {
+    let type_ = res.get("type").unwrap().as_str().unwrap();
+    let encoding = res.get("encoding").unwrap().as_str().unwrap();
+    if type_ != "file" || encoding != "base64" {
+        panic!(
+            "{} {} {} {}",
+            "Error while fetching content from GitHub. Got type:".red(),
+            type_.white(),
+            ", encoding:".red(),
+            encoding.white()
+        )
+    }
+    let content = res
+        .get("content")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .trim()
+        .replace("\n", "");
+    // base64-decode the content
+    let content = BASE64_STANDARD.decode(&content).expect(&format!(
+        "{} [{}]",
+        "Error while base64-decoding file content:".red(),
+        content.white()
+    ));
+    String::from_utf8(content).unwrap()
+}


### PR DESCRIPTION
Add audit for CODEOWNERS files, to check
* If all users mentioned in the file exist and are members of the org
* If all teams mentioned in the file exist

We will also alert if a team is empty.
Also support using the GH API to perform the audit: doing this has trade-offs compared to performing the audit as above (e.g., it will catch users/teams with no write access, but it won't alert on empty teams).

We can also look for all occurrences of a team in CODEOWNERS files across the org.
This is useful to estimate the impact on CODEOWNERS that removing or renaming a team would have.